### PR TITLE
Bump root google-adk pin from 1.26.0 to >=2.8.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 google-cloud-aiplatform==1.139.0
-google-adk==1.26.0
+google-adk>=2.8.0
 fastapi==0.124.1
 uvicorn==0.34.0
 python-dotenv==1.2.2


### PR DESCRIPTION
The repo's root `requirements.txt` pinned `google-adk==1.26.0` (1.x), a full major version behind every actual ADK demo in the tree.

## Version split this fixes

| Location | Was | ADK demos there |
|---|---|---|
| root `requirements.txt` | `==1.26.0` | — |
| `ai/adk/mcp_sa_demo/` | `>=2.0.0,<3.0.0` | MCP + service-account agent |
| `ai/adk/logging/` (+ subdirs) | `>=2.8.0` | logging tutorial, examples, BYOC |

The only code the root pin governs is `ai/adk/adk_callback_examples.py` (no requirements of its own). Its header documents "Verified against google-adk 2.5.0" and its install line is a bare `pip install google-adk`. Its imports (`LlmAgent`, `CallbackContext`, `LlmRequest/LlmResponse`) were confirmed to resolve on an installed ADK 2.5.0. So the 1.x pin never matched the code it covers.

This aligns the root pin to `>=2.8.0`, consistent with the logging demos.

## Relation to Dependabot #26

Supersedes #26 (bump 1.26.0 → 1.28.1). Dependabot could only offer a bump within the 1.x line because of the `==` major pin; it won't cross a major on its own. #26 will be closed as superseded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)