### PR TITLE
ADK logging tutorial: plugin depth (Part 3) and callback-vs-plugin logging (Part 4)

### DIFF
--- a/ai/adk/logging/TUTORIAL.md
+++ b/ai/adk/logging/TUTORIAL.md
@@ -1276,22 +1276,134 @@ asks *"What's the weather in New York?"*:
 {"severity": "INFO", "message": "tool_end", "tool": "get_weather", "latency_ms": 0.2, "status": "ok"}
 ```
 
-**What it means.** Every line is now a machine-readable event. You can compute
-average model latency, sum token usage per session for cost, alert when a tool's
-`status` is `error`, or filter to one tool, all with log queries, because these
-are structured fields and not prose. And nothing here is terminal-specific: swap
-the formatter and the exact same events become Cloud Logging entries in Part 6.
+**What it means.** Every line is now a machine-readable event, not prose. That is
+the prerequisite for querying: the fields you see here (`latency_ms`, `status`,
+`input_tokens`) become keys you can filter, aggregate, and alert on the moment
+these lines reach a log store. Nothing here is terminal-specific either, so the
+same script proves the point in the cloud.
 
-Two things this example teaches by doing:
+**Do this on Cloud Run.** Example 05 runs once and exits, so it is a Cloud Run
+Job, exactly like the plugin scripts in 3.2 and 3.4, and the same deploy helper
+takes this script as its argument:
+
+```bash
+export PROJECT_ID=your-project REGION=us-central1
+SCRIPT=examples/05_structured_plugin.py ./deploy/deploy_plugin_job.sh
+```
+
+Cloud Run ingests the container's stdout automatically, and because each line is
+JSON, Cloud Logging parses it into a `jsonPayload` object with your fields as keys.
+The claim above is now a real query, filtering to one event type and reading
+latency as a number:
+
+```bash
+gcloud logging read \
+  'resource.type="cloud_run_job" jsonPayload.event="tool_end"' \
+  --project="$PROJECT_ID" --freshness=15m \
+  --format='table(jsonPayload.tool, jsonPayload.latency_ms, jsonPayload.status)'
+```
+
+**You will see** the structured fields returned as query columns, not text you
+have to parse:
+
+```console
+TOOL         LATENCY_MS  STATUS
+get_weather  0.5         ok
+```
+
+**What it means.** No formatter change was needed: the JSON you saw on your laptop
+is the JSON Cloud Logging indexed. `jsonPayload.status="error"` is now an alerting
+condition and `jsonPayload.latency_ms` is a metric you can chart, both because the
+plugin emitted structured fields instead of prose, and `severity` rode along in
+the JSON, so Cloud Logging shows these as `INFO` rather than guessing. Part 6
+extends that to a long-running Service, putting the same correct severity *and* a
+shared trace id on **every** stream, including the framework and access logs your
+plugin never touches, so all of one request's lines group together. Tear down the
+job when you are done:
+
+```bash
+gcloud run jobs delete adk-structured-job --project="$PROJECT_ID" --region="$REGION" --quiet
+```
+
+One detail this example teaches by doing:
 
 - **Reserved field names.** Keys in `extra=` must not collide with built-in
   `LogRecord` attributes (`args`, `name`, `message`, `module`). The example uses
   `tool_args`, not `args`, precisely because `args` collides and raises a
   `KeyError` inside the log call. (This one bites everyone once.)
-- **Plugin vs. callback.** A plugin is app-wide: it fires for every agent and
-  every tool. If you only care about one agent or tool, the surgical alternative
-  is a per-agent callback, for example `Agent(..., before_tool_callback=my_fn)`.
-  Reach for a plugin when you want uniform telemetry across the whole app.
+
+### 4.1 Callback or plugin?
+
+**Why you are here.** The plugin above is one of two ways to emit your own
+records; the other is a per-agent callback, and you have probably seen that style
+elsewhere. Before choosing between them, be clear on what this logging is for. It
+does not replace ADK's built-in logging. It sits alongside it, because the two
+answer different questions.
+
+To operate the agent you have to be able to answer questions like:
+
+1. Is the model call failing or being retried?
+2. Which tool ran, with which arguments, and did it succeed?
+3. How many tokens did this turn cost, and what is a session costing?
+
+Set a level on `google_adk` and the framework answers the first on its own:
+requests sent, responses received, retries, and errors, for free. It does not
+answer the second or third in any form you can query. At DEBUG it will dump the
+tool call inside a wall of JSON you cannot filter or aggregate. Questions 2 and 3
+are yours to collect as structured fields, and collecting them is the
+callback-or-plugin job. So the rule is **in addition to the framework logger, not
+instead of it.**
+
+**The per-agent callback.** The same hook points exist on a single agent. Instead
+of a plugin class, you attach a function:
+
+```python
+import logging
+
+telemetry = logging.getLogger("agent.telemetry")   # your namespace, not google_adk
+
+def log_tool(tool, args, tool_context):
+    telemetry.info("tool_call", extra={
+        "event": "tool_call",
+        "tool": tool.name,
+        "tool_args": args,
+        "agent": tool_context.agent_name,
+    })
+    return None   # return a value instead to block or replace the call
+
+root_agent = Agent(..., before_tool_callback=log_tool)
+```
+
+`getLogger("agent.telemetry")` returns a logger under a name you choose; the name
+is arbitrary and unrelated to ADK. It matters for two reasons: you can set its
+level and attach handlers by that same name in your logging config, and the name
+rides on every record, so in Cloud Logging you can filter to `agent.telemetry`
+and see your events without the framework's. Keeping it out of the `google_adk`
+tree is what lets you control the two independently.
+
+**Which to use.** The callback and the plugin run the same hooks; they differ in
+scope.
+
+| Use a plugin when... | Use a per-agent callback when... |
+|---|---|
+| you want uniform telemetry across every agent and tool | the logic belongs to one agent only |
+| the logging carries state (a timer for latency) or config | you are prototyping and want the fewest lines |
+| you want one field schema for downstream BigQuery or Looker analysis | you need to block or rewrite a step for that one agent |
+
+A plugin registers once on the `App` and fires everywhere, which is why it is the
+right default for production telemetry: one place, one schema, every agent. A
+per-agent callback is siloed by design; with several agents the same logging
+drifts across them and you cannot see the whole app at once. Reach for it when
+the logic is genuinely local, or when you want a hook to **short-circuit**:
+returning a value from a `before_*` callback stops or replaces the step, which
+turns the same hook into a guardrail. Note that both callbacks and plugins run in
+the request thread, so keep the work cheap and let the logging handler do the
+shipping.
+
+**The takeaway.** Set a level on ADK's logger to answer framework questions, add
+a plugin (or, for one agent, a callback) to answer the tool and cost questions
+ADK cannot, and route both through one logging config so every agent produces the
+same queryable record.
 
 ## Part 5: a custom server where you own every stream
 
@@ -1660,6 +1772,7 @@ from Part 7, pre-wired.
 | Reading tool calls live in dev | `LoggingPlugin` (3.1, 3.5) | Clean narration + tokens. Prints, so dev only. |
 | Capturing one bad turn in full | `DebugLoggingPlugin` (3.3, 3.5) | Complete YAML record, secrets redacted. |
 | Emitting metrics for production | Custom `BasePlugin` (Part 4) | Real `logging` records; queryable, alertable. |
+| Logging or guarding one agent only | Per-agent callback (4.1) | Siloed by design; can short-circuit a step. |
 | Running your own HTTP server | `dictConfig` + the Part 4 plugin | Own all four streams in one place. |
 | Seeing raw logs reach the cloud, fast | Cloud Run Job/service, no JSON (1.4, 1.5) | Zero setup; but severity is Cloud Run's guess (Default), not yours. |
 | Deploying to Cloud Run for real | JSON to stdout + trace field (Part 6) | Auto-ingested; severity you set; grouped by request. |
@@ -1715,13 +1828,15 @@ AI, Gemini 3.7 Flash):
   the platform owning log format on native Agent Runtime (1.6), the project-level
   `artifactregistry.reader` and reserved-var model-region traps (1.7), are all
   from those runs.
-- The **plugin Cloud Run Jobs in 3.2 and 3.4 were run** against `jwd-gcp-demos`
+- The **plugin Cloud Run Jobs in 3.2, 3.4, and 4 were run** against `jwd-gcp-demos`
   (2026-09-03) with [deploy/deploy_plugin_job.sh](deploy/deploy_plugin_job.sh).
   3.2's two findings (the narration survives `LOG_LEVEL=WARNING` untouched; it
   lands on stdout with Default severity and literal ANSI bytes) and 3.4's (the
   YAML is discarded with the container until a Cloud Storage volume is mounted,
   and the plugin then emits its mode-600 warning against the FUSE mount) are both
-  from those runs.
+  from those runs. Part 4's Job confirmed the structured payoff: the plugin's JSON
+  parsed into queryable `jsonPayload` fields (`event`, `tool`, `latency_ms`,
+  `status`) and its `severity` landed as `INFO`, not Default.
 
 Not verified here (documented, run them yourself):
 

--- a/ai/adk/logging/TUTORIAL.md
+++ b/ai/adk/logging/TUTORIAL.md
@@ -781,6 +781,13 @@ from google.adk.plugins import LoggingPlugin
 app = App(name="demo", root_agent=root_agent, plugins=[LoggingPlugin()])
 ```
 
+The plugin's own docstring is blunt about its scope: it "is not a replacement of
+existing logging in ADK," but rather "helps terminal based debugging" and
+"serves as a simple demo for everyone to leverage when developing new plugins."
+Read this section as much for how to write a plugin as for what this one prints;
+the deployed sections that follow (3.2, 3.4) exist to show why a print-based dev
+tool does not belong in production, not to endorse shipping it.
+
 **How the one line works.** A plugin is a set of lifecycle hooks. `BasePlugin`
 declares fourteen async callbacks, `on_user_message_callback`,
 `before_run_callback`, `before/after_agent_callback`,

--- a/ai/adk/logging/TUTORIAL.md
+++ b/ai/adk/logging/TUTORIAL.md
@@ -765,7 +765,9 @@ you a request happened, not what the tool was called with), and DEBUG dumps the
 full model conversation as raw JSON. In development you often want the middle
 ground: a clean, human-readable narration of the agentic steps, which tool ran,
 with which arguments, what it returned, how many tokens it cost, without writing
-that yourself. ADK ships two plugins for exactly this.
+that yourself. ADK ships two plugins for exactly this. This part uses them
+locally first, then deploys each one to Cloud Run so you can see what a plugin
+sends to Cloud Logging, and closes with when to reach for a plugin at all.
 
 ### 3.1 LoggingPlugin: one line to wire up
 
@@ -779,41 +781,221 @@ from google.adk.plugins import LoggingPlugin
 app = App(name="demo", root_agent=root_agent, plugins=[LoggingPlugin()])
 ```
 
+**How the one line works.** A plugin is a set of lifecycle hooks. `BasePlugin`
+declares fourteen async callbacks, `on_user_message_callback`,
+`before_run_callback`, `before/after_agent_callback`,
+`before/after_model_callback`, `before/after_tool_callback`, `on_event_callback`,
+`after_run_callback`, three error hooks, and `close`, and every one returns
+`None` by default. A plugin subclass overrides only the hooks it cares about.
+`App(plugins=[...])` hands the list to a `PluginManager`, and at each point in a
+run the runner calls the matching hook on every plugin, in registration order,
+before any per-agent callback. The manager uses an early-exit rule:
+
+> if any plugin
+> callback returns a non-`None` value, the execution of subsequent plugins for
+> that specific event is halted, and the returned value is propagated up the
+> call stack.
+
+`LoggingPlugin` returns `None` from every hook, so it never short-circuits
+anything. It is a pure observer that prints and gets out of the way.
+
+**What "no arguments" configures.** `LoggingPlugin()` takes only an optional
+`name`; nothing else is configurable:
+
+```python
+def __init__(self, name: str = "logging_plugin"):
+    super().__init__(name)
+```
+
+Everything about how it writes is fixed in the source:
+
+| Setting | Value | Where |
+|---|---|---|
+| Line prefix | `[logging_plugin]`, the `name` | `_log` |
+| Sink | `print()` to stdout, wrapped in grey ANSI codes | `_log` |
+| Level, handler, formatter | none; the `logging` module is never touched | whole file |
+| Text and system-instruction length | truncated at 200 characters | `_format_content` |
+| Tool arguments and results length | truncated at 300 characters | `_format_args` |
+
+The sink is the whole story, and it is four lines:
+
+```python
+def _log(self, message: str) -> None:
+    # ANSI color codes: \033[90m for grey, \033[0m to reset
+    formatted_message: str = f"\033[90m[{self.name}] {message}\033[0m"
+    print(formatted_message)
+```
+
+Each hook just formats a few fields and calls `_log`. For example the
+`TOOL STARTING` block you will see below is produced by `before_tool_callback`:
+
+```python
+async def before_tool_callback(self, *, tool, tool_args, tool_context):
+    self._log(f"🔧 TOOL STARTING")
+    self._log(f"   Tool Name: {tool.name}")
+    self._log(f"   Agent: {tool_context.agent_name}")
+    self._log(f"   Function Call ID: {tool_context.function_call_id}")
+    self._log(f"   Arguments: {self._format_args(tool_args)}")
+    return None
+```
+
+Because everything goes through `print()`, neither `--log_level` nor a
+`dictConfig` can reach this output. That is the trait that decides where you use
+it, called out at the end of this section.
+
 **Do this.**
 
 ```bash
 .venv/bin/python examples/03_logging_plugin.py
 ```
 
-The example asks *"What's the weather in London?"* **You will see** a narrated
-lifecycle (trimmed here to the interesting middle):
+The example asks *"What's the weather in London?"* **You will see** the whole
+invocation narrated, one hook at a time (lightly trimmed, repeated field lines
+removed):
 
 ```console
+[logging_plugin] 🚀 USER MESSAGE RECEIVED
+[logging_plugin]    User Content: text: 'What's the weather in London?'
+[logging_plugin] 🏃 INVOCATION STARTING
+[logging_plugin] 🤖 AGENT STARTING
+[logging_plugin]    Agent Name: weather_agent
+[logging_plugin] 🧠 LLM REQUEST
+[logging_plugin]    Model: gemini-3.7-flash
+[logging_plugin]    System Instruction: 'You are a concise weather assistant. ...'
+[logging_plugin]    Available Tools: ['get_weather']
 [logging_plugin] 🧠 LLM RESPONSE
 [logging_plugin]    Content: function_call: get_weather
-[logging_plugin]    Token Usage - Input: 140, Output: 5
+[logging_plugin]    Token Usage - Input: 167, Output: 16
+[logging_plugin] 📢 EVENT YIELDED
+[logging_plugin]    Function Calls: ['get_weather']
 [logging_plugin] 🔧 TOOL STARTING
 [logging_plugin]    Tool Name: get_weather
 [logging_plugin]    Arguments: {'city': 'London'}
 [logging_plugin] 🔧 TOOL COMPLETED
 [logging_plugin]    Result: {'status': 'ok', 'report': 'The weather in London is 15C and drizzling.'}
+[logging_plugin] 📢 EVENT YIELDED
+[logging_plugin]    Function Responses: ['get_weather']
+[logging_plugin] 🧠 LLM REQUEST
+[logging_plugin] 🧠 LLM RESPONSE
+[logging_plugin]    Content: text: 'The weather in London is currently 15°C and drizzling.'
+[logging_plugin]    Token Usage - Input: 228, Output: 15
+[logging_plugin] 📢 EVENT YIELDED
+[logging_plugin]    Final Response: True
+[logging_plugin] 🤖 AGENT COMPLETED
+[logging_plugin] ✅ INVOCATION COMPLETED
 ```
 
-**What it means.** In one glance you can see the model chose to call `get_weather`
-with `{'city': 'London'}`, what came back, and that the deciding model call cost
-140 input and 5 output tokens. This is the view you want when a tool is being
-called with the wrong arguments, or not called when it should be, and you do not
-want to parse DEBUG to find out. Compare it to the DEBUG output from Part 1: same
-information about the tool call, far less noise.
+**What it means.** That is the full agentic loop, in order: the model saw the
+tools and chose `get_weather`, the tool ran with `{'city': 'London'}` and
+returned its report, the model was called a second time with that result and
+produced the final text, and the run ended. Two model calls, one tool call, and
+their token costs (167 plus 16 to decide the call, 228 plus 15 to write the
+answer), all without parsing DEBUG. This is the view you want when a tool is
+called with the wrong arguments, or not called when it should be.
+
+**What you will not see.** `LLM REQUEST` prints the model, the first 200
+characters of the system instruction, and the tool names, but not the
+conversation contents. The source removed that on purpose:
+
+```python
+# Note: Content logging removed due to type compatibility issues
+# Users can still see content in the LLM response
+```
+
+So the exact prompt sent to the model is still a DEBUG or `DebugLoggingPlugin`
+job, which is what 3.3 is for.
 
 > **The catch that decides where you use it.** `LoggingPlugin` writes with
 > `print()` and ANSI color codes, **not** through the `logging` module. That is
 > perfect in a terminal and wrong for a deployed service: it ignores your
 > handlers, levels, and formatters, and the color bytes corrupt a JSON log line.
 > Use it for local debugging. When you need this information *in production*, use
-> the structured plugin in Part 4 instead.
+> the structured plugin in Part 4 instead. The next section shows exactly what
+> that catch looks like once the same script runs on Cloud Run.
 
-### 3.2 DebugLoggingPlugin: capture one whole turn to a file
+### 3.2 LoggingPlugin on Cloud Run
+
+**Why you are here.** The callout above is a claim about a deployed service. This
+section is the evidence. It is the same move as 1.4: deploy the unmodified script
+as a Cloud Run Job, run it, and read back what Cloud Logging did with each line.
+[deploy/deploy_plugin_job.sh](deploy/deploy_plugin_job.sh) builds one image that
+can run either plugin example; the script to run is the Job argument, and
+`LOG_LEVEL` is an environment variable, so you can change the framework level
+between runs without rebuilding. Example 03 configures no logging of its own, so
+`LOG_LEVEL` controls only the framework logger (stream 2), never the plugin.
+
+**Do this.** Deploy and run once at INFO, then run again at WARNING:
+
+```bash
+export PROJECT_ID=your-project REGION=us-central1
+SCRIPT=examples/03_logging_plugin.py ./deploy/deploy_plugin_job.sh   # deploys adk-plugin-job, runs at INFO
+gcloud run jobs execute adk-plugin-job \
+  --project="$PROJECT_ID" --region="$REGION" \
+  --update-env-vars=LOG_LEVEL=WARNING --wait
+```
+
+Then read the plugin's own lines, and separately the framework's, back:
+
+```bash
+# The plugin narration (stdout):
+gcloud logging read \
+  'resource.type="cloud_run_job" resource.labels.job_name="adk-plugin-job"
+   textPayload:"logging_plugin"' \
+  --project="$PROJECT_ID" --limit=10 \
+  --format='value(severity,textPayload)' --freshness=15m
+
+# The framework lines (stderr):
+gcloud logging read \
+  'resource.type="cloud_run_job" resource.labels.job_name="adk-plugin-job"
+   textPayload:"google_adk"' \
+  --project="$PROJECT_ID" --limit=10 \
+  --format='value(severity,textPayload)' --freshness=15m
+```
+
+**You will see** two things worth stopping on.
+
+First, the narration is unchanged by the level. Both the INFO run and the
+WARNING run carry the full `[logging_plugin]` narration; the WARNING run just has
+no `google_adk` lines next to it. The framework query returns rows for the INFO
+run and nothing for the WARNING run:
+
+```console
+INFO - google_adk.google.adk.plugins.plugin_manager - Plugin 'logging_plugin' registered.
+INFO - google_adk.google.adk.models.google_llm - Sending out request, model: gemini-3.7-flash, ...
+INFO - google_adk.google.adk.models.google_llm - Response received from the model.
+```
+
+Second, the narration reaches the cloud as raw terminal bytes. The severity
+column is blank (Default) for every plugin line, and the ANSI codes arrive
+literally in the payload:
+
+```console
+<no severity>  ^[[90m[logging_plugin] 🔧 TOOL STARTING^[[0m
+<no severity>  ^[[90m[logging_plugin]    Arguments: {'city': 'London'}^[[0m
+```
+
+**What it means, finding one: the plugin is independent of the level dial.**
+Turning stream 2 down to WARNING removed the framework's lifecycle lines and left
+the plugin narration completely intact, because the plugin never goes through
+`logging`. That is exactly what makes it great in development, and exactly why it
+is the wrong tool in production: you cannot turn it down without deleting it from
+the code.
+
+**What it means, finding two: the narration is not queryable.** Every plugin
+line lands on stdout with Default severity and its grey ANSI codes embedded in
+the text. It is readable in the console, but nothing in it is a field you can
+filter, alert on, or group. (The `google_adk` lines have the same problem 1.4
+found: they are on stderr and still come through as Default, not ERROR.) Making
+this information queryable is the job of Part 4, which feeds the same hook data
+through the `logging` module instead of `print()`.
+
+Tear down when you are done:
+
+```bash
+gcloud run jobs delete adk-plugin-job --project="$PROJECT_ID" --region="$REGION" --quiet
+```
+
+### 3.3 DebugLoggingPlugin: capture one whole turn to a file
 
 **Why.** Sometimes one specific turn misbehaves and you want the complete,
 inspectable record to diff or attach to a bug report, not a stream you have to
@@ -824,6 +1006,59 @@ from google.adk.plugins import DebugLoggingPlugin
 plugin = DebugLoggingPlugin(output_path="adk_debug.yaml")
 ```
 
+**How it differs from `LoggingPlugin`.** Both subclass `BasePlugin` and override
+the same hooks, but almost everything else is opposite:
+
+| | `LoggingPlugin` | `DebugLoggingPlugin` |
+|---|---|---|
+| Sink | `print()` to stdout | a YAML file |
+| When it writes | immediately, at every hook | buffered in memory, written once per invocation in `after_run_callback` |
+| Detail | truncated; no request contents | full request contents, config, tool list, responses, session state |
+| Redaction | none | credential models, secret-named keys, private-key blocks, all `temp:` state |
+| File safety | not applicable | created `0600`; warns once if an existing file is wider |
+| Own diagnostics | none | emits real `logging` warnings and errors |
+
+Its constructor exposes the knobs the terminal plugin does not have, all
+keyword-only:
+
+```python
+def __init__(
+    self,
+    *,
+    name: str = "debug_logging_plugin",
+    output_path: str = "adk_debug.yaml",
+    include_session_state: bool = True,
+    include_system_instruction: bool = True,
+):
+```
+
+Where `LoggingPlugin` formats a line and prints it, this plugin records the
+request as structured data. Its `before_model_callback` keeps the whole thing:
+
+```python
+request_data = {
+    "model": llm_request.model,
+    "content_count": len(llm_request.contents),
+    "contents": [self._serialize_content(c) for c in llm_request.contents],
+}
+if llm_request.tools_dict:
+    request_data["tools"] = list(llm_request.tools_dict.keys())
+self._add_entry(callback_context.invocation_id, "llm_request", **request_data)
+```
+
+Nothing is written until the invocation ends. `after_run_callback` dumps the
+buffered entries as one YAML document, and it takes care to create the file
+readable only by its owner:
+
+```python
+fd = os.open(self._output_path,
+             os.O_WRONLY | os.O_CREAT | os.O_APPEND, _OUTPUT_FILE_MODE)  # 0o600
+with os.fdopen(fd, "a", encoding="utf-8") as f:
+    f.write("---\n")
+    yaml.dump(output_data, f, default_flow_style=False,
+              allow_unicode=True, sort_keys=False, width=120)
+```
+
 **Do this**, then open the file it writes:
 
 ```bash
@@ -831,10 +1066,15 @@ plugin = DebugLoggingPlugin(output_path="adk_debug.yaml")
 cat adk_debug.yaml
 ```
 
-**You will see** one YAML document per invocation:
+Example 04 passes `include_session_state=True` and
+`include_system_instruction=True` explicitly. Both are already the defaults; they
+are written out so you can see the knobs exist.
+
+**You will see** one YAML document for the invocation, a list of timestamped
+entries:
 
 ```console
-- timestamp: '2026-08-31T20:05:03.639120'
+- timestamp: '2026-09-03T23:54:59.413524'
   entry_type: llm_request
   data:
     model: gemini-3.7-flash
@@ -842,13 +1082,141 @@ cat adk_debug.yaml
     - role: user
       parts:
       - text: What's the weather in a city you don't know, like Paris?
+    tools:
+    - get_weather
 ```
 
+The `entry_type` values, in order, trace the same lifecycle the terminal plugin
+narrates: `invocation_start`, `agent_start`, `llm_request`, `llm_response`,
+`event`, `tool_call`, `tool_response`, `event`, a second `llm_request` and
+`llm_response`, `event`, `agent_end`, `session_state_snapshot`,
+`invocation_end`.
+
 **What it means.** It is the full turn on disk: exact prompt, system instruction,
-tool arguments, tool results, token counts, and session state. Credentials and
-`temp:` state are redacted, and the file is created readable only by you
-(`0600`). Treat it as sensitive, it holds full prompt content by design. This is
-a debugging capture, not a log sink you leave running.
+tool arguments, tool results, token counts, and session state. Two properties
+matter. It is buffered, so nothing reaches the file until the invocation
+completes; if the process dies mid-turn, that turn is lost. And it redacts by
+design, but broadly:
+
+> That last rule blanks all temporary state, not
+> only credentials, so an intermediate value passed between agents under a
+> `temp:` key reads as `[REDACTED]` here.
+
+The file still holds full prompt content, so it is created `0600` and should be
+treated as sensitive. This is a debugging capture, not a log sink you leave
+running. Example 04 also reads its output path from a `DEBUG_OUTPUT` environment
+variable when one is set, which the next section uses to redirect the capture off
+the container.
+
+### 3.4 DebugLoggingPlugin on Cloud Run
+
+**Why you are here.** 3.3 wrote a file. A Cloud Run Job's filesystem is thrown
+away when the execution ends. So where does the capture go? The answer is a
+short, useful lesson about file-writing tools in ephemeral containers.
+
+**Do this**, part one, the naive deploy:
+
+```bash
+SCRIPT=examples/04_debug_plugin.py ./deploy/deploy_plugin_job.sh   # deploys adk-debug-plugin-job
+gcloud logging read \
+  'resource.type="cloud_run_job" resource.labels.job_name="adk-debug-plugin-job"' \
+  --project="$PROJECT_ID" --limit=20 \
+  --format='value(severity,textPayload)' --freshness=15m
+```
+
+**You will see** the script's two `print()` lines and nothing resembling the
+YAML:
+
+```console
+FINAL ANSWER: I do not have weather data for Paris.
+Full invocation captured to: /app/adk_debug.yaml
+WARNING - google_adk.google.adk.plugins.debug_logging_plugin - No debug state for invocation e-..., skipping entry
+```
+
+The file was written to `/app/adk_debug.yaml` inside the container and discarded
+with it. (The `skipping entry` warning is a harmless ADK ordering quirk: the
+plugin's `on_user_message_callback` fires before `before_run_callback` creates
+the per-invocation buffer, so the first entry is dropped. Notice it is a real
+`logging` record on stderr, unlike anything `LoggingPlugin` emits.)
+
+**What it means.** A file-writing plugin needs a filesystem that outlives the
+execution. Cloud Run can mount a Cloud Storage bucket as a volume, and example 04
+already reads its path from `DEBUG_OUTPUT`.
+
+**Do this**, part two, mount a bucket:
+
+```bash
+export BUCKET="${PROJECT_ID}-adk-debug"   # any bucket you own; created in $REGION if missing
+MOUNT=1 SCRIPT=examples/04_debug_plugin.py ./deploy/deploy_plugin_job.sh
+gcloud storage cat "gs://$BUCKET/adk_debug.yaml" | head -40
+```
+
+With `MOUNT=1` the deploy script mounts `$BUCKET` at `/mnt/out` and sets
+`DEBUG_OUTPUT=/mnt/out/adk_debug.yaml` on the Job.
+
+**You will see** the same YAML document as 3.3, now read back from the bucket,
+with the full `entry_type` sequence intact. Check Cloud Logging for one more
+line the plugin emits about the file it just wrote:
+
+```console
+WARNING - google_adk.google.adk.plugins.debug_logging_plugin - Debug output file /mnt/out/adk_debug.yaml is readable beyond its owner and holds whole prompts and responses; restrict it to mode 600.
+```
+
+**What it means.** The plugin behaved exactly as on your laptop; only the disk
+changed. The mode warning is the plugin doing its job: the Cloud Storage FUSE
+mount reports a mode wider than `0600`, so the plugin cannot guarantee the file
+is owner-only and says so, through the `logging` module, on stderr. Two cautions
+follow from that. The capture now lives in a bucket and still holds full prompts,
+so bucket IAM is your new `0600`. And this is still a debugging capture, not a
+log pipeline; if you find yourself running it routinely in the cloud, you want
+the structured plugin in Part 4 instead.
+
+> A quick alternative, if you only need the capture once and do not want a
+> bucket: have the script `cat` the file to stdout at the end, and it lands in
+> Cloud Logging as one large text payload. It works, but it throws away the
+> "file, not stream" property that made the plugin worth using.
+
+Tear down when you are done:
+
+```bash
+gcloud run jobs delete adk-debug-plugin-job --project="$PROJECT_ID" --region="$REGION" --quiet
+```
+
+### 3.5 Plugin or level dial?
+
+**Why you are here.** You have now seen both plugins, locally and deployed. When
+should you reach for one instead of just turning the `google_adk` level up? The
+short answer: when you want structured facts about the agent's steps rather than
+the framework's own log prose.
+
+Built-in ADK logging is text lines under `google_adk`, at whatever level you set.
+A plugin hooks the same lifecycle but receives objects, at named points, before
+those lines are ever formatted. That difference buys four things:
+
+| Benefit | What it means in practice |
+|---|---|
+| Objects, not strings | `after_model_callback` receives an `LlmResponse` with `usage_metadata`; you read token counts as numbers, never parse a DEBUG dump |
+| Independent of the level | 3.2 proved it: WARNING silenced the framework and the plugin narration kept going |
+| One registration, app-wide | a plugin fires for every agent and tool in the `App`; a per-agent callback has to be wired onto each agent |
+| You own the sink | the same hook data feeds `print()` (3.1), a YAML file (3.3), JSON `logging` records (Part 4), or BigQuery |
+
+What the level dial still does better: DEBUG shows the framework's own internals,
+the wire-level request, HTTP retries, and session-service work, none of which
+have plugin hooks. The two are complementary, not rivals.
+
+Three cases where a plugin is the right call:
+
+1. **A tool is getting the wrong arguments in development.** Run the framework at
+   WARNING so its lines are quiet, attach `LoggingPlugin`, and watch the
+   `Arguments:` lines. You see the tool calls and nothing else.
+2. **You need a reproducible bug report.** Attach `DebugLoggingPlugin`, reproduce
+   the turn, and attach the YAML. Or capture one document before a prompt change
+   and one after, and diff them. From a Cloud Run Job, that means the mounted
+   bucket from 3.4.
+3. **You are watching token cost while tuning a prompt.** Read `Token Usage` per
+   model call from `LoggingPlugin`, or `usage_metadata` from the YAML, with no
+   formatter to write. When you want those numbers queryable in production, Part
+   4 turns the same hook into structured log fields.
 
 ## Part 4: production logging you own
 
@@ -1274,8 +1642,8 @@ from Part 7, pre-wired.
 |---|---|---|
 | Getting the shape of a run | `--log_level INFO` | Lifecycle without contents. |
 | Debugging what the model saw | `--log_level DEBUG` | Full prompt, history, tool schema. |
-| Reading tool calls live in dev | `LoggingPlugin` | Clean narration + tokens. Prints, so dev only. |
-| Capturing one bad turn in full | `DebugLoggingPlugin` | Complete YAML record, secrets redacted. |
+| Reading tool calls live in dev | `LoggingPlugin` (3.1, 3.5) | Clean narration + tokens. Prints, so dev only. |
+| Capturing one bad turn in full | `DebugLoggingPlugin` (3.3, 3.5) | Complete YAML record, secrets redacted. |
 | Emitting metrics for production | Custom `BasePlugin` (Part 4) | Real `logging` records; queryable, alertable. |
 | Running your own HTTP server | `dictConfig` + the Part 4 plugin | Own all four streams in one place. |
 | Seeing raw logs reach the cloud, fast | Cloud Run Job/service, no JSON (1.4, 1.5) | Zero setup; but severity is Cloud Run's guess (Default), not yours. |
@@ -1331,6 +1699,13 @@ AI, Gemini 3.7 Flash):
   that differ from common advice, stderr landing as Default not ERROR (1.4/1.5),
   the platform owning log format on native Agent Runtime (1.6), the project-level
   `artifactregistry.reader` and reserved-var model-region traps (1.7), are all
+  from those runs.
+- The **plugin Cloud Run Jobs in 3.2 and 3.4 were run** against `jwd-gcp-demos`
+  (2026-09-03) with [deploy/deploy_plugin_job.sh](deploy/deploy_plugin_job.sh).
+  3.2's two findings (the narration survives `LOG_LEVEL=WARNING` untouched; it
+  lands on stdout with Default severity and literal ANSI bytes) and 3.4's (the
+  YAML is discarded with the container until a Cloud Storage volume is mounted,
+  and the plugin then emits its mode-600 warning against the FUSE mount) are both
   from those runs.
 
 Not verified here (documented, run them yourself):

--- a/ai/adk/logging/TUTORIAL.md
+++ b/ai/adk/logging/TUTORIAL.md
@@ -784,9 +784,12 @@ app = App(name="demo", root_agent=root_agent, plugins=[LoggingPlugin()])
 The plugin's own docstring is blunt about its scope: it "is not a replacement of
 existing logging in ADK," but rather "helps terminal based debugging" and
 "serves as a simple demo for everyone to leverage when developing new plugins."
-Read this section as much for how to write a plugin as for what this one prints;
-the deployed sections that follow (3.2, 3.4) exist to show why a print-based dev
-tool does not belong in production, not to endorse shipping it.
+Read this section as much for how to write a plugin as for what this one prints.
+The two deployed sections that follow (3.2, 3.4) are optional. We ran these
+plugins on Cloud Run to satisfy a fair question, what would the cloud even do
+with them, and the answer is instructive. But the takeaway is that you would not
+actually ship either one; skip ahead to Part 4 if you only want the production
+path.
 
 **How the one line works.** A plugin is a set of lifecycle hooks. `BasePlugin`
 declares fourteen async callbacks, `on_user_message_callback`,
@@ -922,9 +925,12 @@ job, which is what 3.3 is for.
 
 ### 3.2 LoggingPlugin on Cloud Run
 
-**Why you are here.** The callout above is a claim about a deployed service. This
-section is the evidence. It is the same move as 1.4: deploy the unmodified script
-as a Cloud Run Job, run it, and read back what Cloud Logging did with each line.
+**Optional. Why you are here.** You would not deploy `LoggingPlugin` to a real
+service; this section exists only to satisfy the natural curiosity about what
+Cloud Run does with a print-based plugin, and the answer turns the 3.1 callout
+from a claim into evidence. It is the same move as 1.4: deploy the unmodified
+script as a Cloud Run Job, run it, and read back what Cloud Logging did with each
+line.
 [deploy/deploy_plugin_job.sh](deploy/deploy_plugin_job.sh) builds one image that
 can run either plugin example; the script to run is the Job argument, and
 `LOG_LEVEL` is an environment variable, so you can change the framework level
@@ -1117,9 +1123,11 @@ the container.
 
 ### 3.4 DebugLoggingPlugin on Cloud Run
 
-**Why you are here.** 3.3 wrote a file. A Cloud Run Job's filesystem is thrown
-away when the execution ends. So where does the capture go? The answer is a
-short, useful lesson about file-writing tools in ephemeral containers.
+**Optional. Why you are here.** Like 3.2, this is a curiosity-driven detour, not
+a step you need. You would not run `DebugLoggingPlugin` on Cloud Run in practice,
+but doing it once teaches a real lesson about file-writing tools in ephemeral
+containers. 3.3 wrote a file; a Cloud Run Job's filesystem is thrown away when
+the execution ends. So where does the capture go?
 
 **Do this**, part one, the naive deploy:
 

--- a/ai/adk/logging/deploy/Dockerfile.plugin_job
+++ b/ai/adk/logging/deploy/Dockerfile.plugin_job
@@ -1,0 +1,20 @@
+# Container for the plugin example scripts (examples/03_logging_plugin.py and
+# examples/04_debug_plugin.py) as a Cloud Run Job, tutorial 3.2 and 3.4. Like
+# Dockerfile.job, each script runs once and exits, so a Job (not a Service) is
+# the honest fit. The difference: the script path is passed as the Job argument
+# at execution time, so one image serves both examples.
+
+FROM python:3.13-slim
+
+WORKDIR /app
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY demo_agent/ ./demo_agent/
+COPY examples/ ./examples/
+
+# The script to run is the Job argument
+# (gcloud run jobs execute ... --args=examples/03_logging_plugin.py), so the
+# entrypoint is the interpreter with no fixed script.
+ENTRYPOINT ["python"]

--- a/ai/adk/logging/deploy/deploy_plugin_job.sh
+++ b/ai/adk/logging/deploy/deploy_plugin_job.sh
@@ -1,10 +1,10 @@
 #!/usr/bin/env bash
 #
-# Tutorial 3.2 and 3.4: deploy a plugin example script as a Cloud Run JOB and
-# execute it once, to see what the built-in ADK plugins send to Cloud Logging.
-# Each script runs once and exits, so a Job is the honest fit (a Service would
-# fail its readiness check with no port). One image serves both examples; the
-# script to run is the Job argument. OPTIONAL step.
+# Tutorial 3.2, 3.4, and 4: deploy a plugin example script as a Cloud Run JOB and
+# execute it once, to see what its plugin sends to Cloud Logging. Each script runs
+# once and exits, so a Job is the honest fit (a Service would fail its readiness
+# check with no port). One image serves every script; the script to run is the
+# Job argument. OPTIONAL step.
 #
 # Usage:
 #   export PROJECT_ID=your-project
@@ -20,6 +20,13 @@
 #   MOUNT=1 SCRIPT=examples/04_debug_plugin.py ./deploy/deploy_plugin_job.sh
 #   gcloud storage cat "gs://$BUCKET/adk_debug.yaml" | head -40
 #
+#   # 4 -- StructuredTelemetryPlugin, then query the structured fields:
+#   SCRIPT=examples/05_structured_plugin.py ./deploy/deploy_plugin_job.sh
+#   gcloud logging read \
+#     'resource.type="cloud_run_job" jsonPayload.event="tool_end"' \
+#     --project="$PROJECT_ID" --freshness=15m \
+#     --format='table(jsonPayload.tool, jsonPayload.latency_ms, jsonPayload.status)'
+#
 set -euo pipefail
 
 PROJECT_ID="${PROJECT_ID:?set PROJECT_ID}"
@@ -30,8 +37,9 @@ LOG_LEVEL="${LOG_LEVEL:-INFO}"
 
 # Job name derives from the script so 03 and 04 get distinct jobs by default.
 case "$SCRIPT" in
-  *04_debug_plugin.py) DEFAULT_JOB="adk-debug-plugin-job" ;;
-  *)                   DEFAULT_JOB="adk-plugin-job" ;;
+  *04_debug_plugin.py)      DEFAULT_JOB="adk-debug-plugin-job" ;;
+  *05_structured_plugin.py) DEFAULT_JOB="adk-structured-job" ;;
+  *)                        DEFAULT_JOB="adk-plugin-job" ;;
 esac
 JOB="${JOB:-$DEFAULT_JOB}"
 

--- a/ai/adk/logging/deploy/deploy_plugin_job.sh
+++ b/ai/adk/logging/deploy/deploy_plugin_job.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+#
+# Tutorial 3.2 and 3.4: deploy a plugin example script as a Cloud Run JOB and
+# execute it once, to see what the built-in ADK plugins send to Cloud Logging.
+# Each script runs once and exits, so a Job is the honest fit (a Service would
+# fail its readiness check with no port). One image serves both examples; the
+# script to run is the Job argument. OPTIONAL step.
+#
+# Usage:
+#   export PROJECT_ID=your-project
+#   export REGION=us-central1
+#
+#   # 3.2 -- LoggingPlugin, run at INFO then WARNING:
+#   SCRIPT=examples/03_logging_plugin.py ./deploy/deploy_plugin_job.sh
+#   gcloud run jobs execute adk-plugin-job --project="$PROJECT_ID" \
+#     --region="$REGION" --update-env-vars=LOG_LEVEL=WARNING --wait
+#
+#   # 3.4 -- DebugLoggingPlugin, capture to a mounted Cloud Storage bucket:
+#   export BUCKET="${PROJECT_ID}-adk-debug"
+#   MOUNT=1 SCRIPT=examples/04_debug_plugin.py ./deploy/deploy_plugin_job.sh
+#   gcloud storage cat "gs://$BUCKET/adk_debug.yaml" | head -40
+#
+set -euo pipefail
+
+PROJECT_ID="${PROJECT_ID:?set PROJECT_ID}"
+REGION="${REGION:-us-central1}"
+MODEL_LOCATION="${MODEL_LOCATION:-global}"
+SCRIPT="${SCRIPT:-examples/03_logging_plugin.py}"
+LOG_LEVEL="${LOG_LEVEL:-INFO}"
+
+# Job name derives from the script so 03 and 04 get distinct jobs by default.
+case "$SCRIPT" in
+  *04_debug_plugin.py) DEFAULT_JOB="adk-debug-plugin-job" ;;
+  *)                   DEFAULT_JOB="adk-plugin-job" ;;
+esac
+JOB="${JOB:-$DEFAULT_JOB}"
+
+# Run from the folder root so the build context has demo_agent/ and examples/.
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT"
+
+# `gcloud run ... --source` auto-detects ./Dockerfile at the build root. Put
+# ours there for the build, and remove it afterward whether or not we succeed.
+cp deploy/Dockerfile.plugin_job ./Dockerfile
+trap 'rm -f "$ROOT/Dockerfile"' EXIT
+
+ENV_VARS="GOOGLE_GENAI_USE_VERTEXAI=TRUE,GOOGLE_CLOUD_PROJECT=${PROJECT_ID},GOOGLE_CLOUD_LOCATION=${MODEL_LOCATION},LOG_LEVEL=${LOG_LEVEL}"
+
+# Optional Cloud Storage volume so a file-writing plugin (example 04) survives
+# the execution. Without it, the Job's filesystem is discarded on exit.
+VOLUME_ARGS=()
+if [[ "${MOUNT:-}" == "1" ]]; then
+  BUCKET="${BUCKET:-${PROJECT_ID}-adk-debug}"
+  if ! gcloud storage buckets describe "gs://$BUCKET" --project="$PROJECT_ID" >/dev/null 2>&1; then
+    echo "Creating bucket gs://$BUCKET in $REGION..."
+    gcloud storage buckets create "gs://$BUCKET" --project="$PROJECT_ID" --location="$REGION"
+  fi
+  ENV_VARS="${ENV_VARS},DEBUG_OUTPUT=/mnt/out/adk_debug.yaml"
+  VOLUME_ARGS=(
+    "--add-volume=name=out,type=cloud-storage,bucket=$BUCKET"
+    "--add-volume-mount=volume=out,mount-path=/mnt/out"
+  )
+fi
+
+echo "Deploying Cloud Run Job '$JOB' to run '$SCRIPT' (LOG_LEVEL=$LOG_LEVEL)..."
+gcloud run jobs deploy "$JOB" \
+  --project="$PROJECT_ID" --region="$REGION" \
+  --source=. \
+  --args="$SCRIPT" \
+  --set-env-vars="$ENV_VARS" \
+  ${VOLUME_ARGS[@]+"${VOLUME_ARGS[@]}"}
+
+echo
+echo "Executing job (waits for completion)..."
+gcloud run jobs execute "$JOB" --project="$PROJECT_ID" --region="$REGION" --wait
+
+cat <<EOF
+
+Done. The script's stdout/stderr went to Cloud Logging. Read it back:
+
+  gcloud logging read \\
+    'resource.type="cloud_run_job" resource.labels.job_name="$JOB"' \\
+    --project="$PROJECT_ID" --limit=60 --format='table(severity,textPayload)' --freshness=15m
+
+  # Re-run at a different level without redeploying (example 03):
+  gcloud run jobs execute "$JOB" --project="$PROJECT_ID" --region="$REGION" \\
+    --update-env-vars=LOG_LEVEL=WARNING --wait
+
+  # Tear down:
+  gcloud run jobs delete "$JOB" --project="$PROJECT_ID" --region="$REGION" --quiet
+EOF

--- a/ai/adk/logging/examples/03_logging_plugin.py
+++ b/ai/adk/logging/examples/03_logging_plugin.py
@@ -30,11 +30,10 @@ from _common import ask, bootstrap
 
 bootstrap()
 
+from demo_agent.agent import root_agent
 from google.adk.apps.app import App
 from google.adk.plugins import LoggingPlugin
 from google.adk.runners import InMemoryRunner
-
-from demo_agent.agent import root_agent
 
 
 async def main() -> None:

--- a/ai/adk/logging/examples/04_debug_plugin.py
+++ b/ai/adk/logging/examples/04_debug_plugin.py
@@ -25,6 +25,7 @@ Run it
 from __future__ import annotations
 
 import asyncio
+import os
 from pathlib import Path
 
 from _common import ask, bootstrap
@@ -37,7 +38,9 @@ from google.adk.runners import InMemoryRunner
 
 from demo_agent.agent import root_agent
 
-OUTPUT = Path(__file__).resolve().parent.parent / "adk_debug.yaml"
+# Default next to the tutorial; tutorial 3.4 sets DEBUG_OUTPUT to a mounted
+# Cloud Storage path so the capture survives a Cloud Run Job execution.
+OUTPUT = Path(os.getenv("DEBUG_OUTPUT") or Path(__file__).resolve().parent.parent / "adk_debug.yaml")
 
 
 async def main() -> None:

--- a/docs/adk-logging-part3-plugin-depth.md
+++ b/docs/adk-logging-part3-plugin-depth.md
@@ -1,0 +1,433 @@
+# Plan: deepen Part 3 of the ADK logging tutorial
+
+Tutorial: `ai/adk/logging/TUTORIAL.md`, lines 761-851 (Part 3). Goal: explain
+how the two built-in plugins actually work, using the real source from
+`google-adk 2.8.0` (`.venv/lib/python3.13/site-packages/google/adk/plugins/`),
+take each plugin script to Cloud Run as a Job the way 1.4 did, and say when a
+plugin beats the level dial. Keep the tutorial's
+"Why you are here / Do this / You will see / What it means" rhythm.
+
+## The asks, restated
+
+| # | Ask | Proposed shape |
+|---|---|---|
+| 1 | 3.1: how `LoggingPlugin` works, default config, real snippet, expected behavior | "How it works" block between the wiring snippet and **Do this**, a full (untrimmed) console block, and a "what you will not see" note |
+| 2 | After 3.1: deploy example 03 as a Cloud Run Job and test it like 1.4 | New **3.2 LoggingPlugin on Cloud Run** |
+| 3 | 3.2 (now 3.3): how `DebugLoggingPlugin` differs, with snippets | Comparison table plus three short source snippets (constructor, capture, write) |
+| 4 | After that: deploy example 04 as a Cloud Run Job and test it | New **3.4 DebugLoggingPlugin on Cloud Run** |
+| 5 | Benefits of a plugin over built-in ADK logging, with use cases | New **3.5 Plugin or level dial?** |
+
+## New Part 3 layout
+
+| Section | Content | Status |
+|---|---|---|
+| 3.1 LoggingPlugin: one line to wire up | existing, expanded (ask 1) | edit |
+| 3.2 LoggingPlugin on Cloud Run | new (ask 2) | new |
+| 3.3 DebugLoggingPlugin: capture one whole turn to a file | existing 3.2, expanded (ask 3) | renumber, edit |
+| 3.4 DebugLoggingPlugin on Cloud Run | new (ask 4) | new |
+| 3.5 Plugin or level dial? | new (ask 5) | new |
+
+Nothing outside Part 3 references "3.1" or "3.2" by number (checked), so the
+renumbering touches only Part 3 headings and the "How to choose" table.
+
+## Decisions / assumptions (review these)
+
+- **D1: source snippets are quoted from the installed 2.8.0 package**, trimmed
+  but not paraphrased, and cited as `google/adk/plugins/logging_plugin.py`.
+- **D2: the "why" goes in 3.5, not inside 3.1**, so **Do this** stays near the
+  top of 3.1 and the "How to choose" table has something to point back to.
+- **D3: re-run examples 03 and 04 locally** to capture untrimmed output and
+  the YAML `entry_type` list. Two runs.
+- **D4: example 04 keeps its explicit keyword arguments.** Both are the
+  defaults; the text says they are shown so you know the knobs exist.
+- **D5: one new Dockerfile and one new deploy script for both jobs**, instead
+  of touching 1.4's `Dockerfile.job` / `deploy_job.sh`. The 1.4 Dockerfile bakes
+  `01_log_levels.py` into `ENTRYPOINT`, and 1.4's text relies on
+  `--args=warning` at execute time. Changing that to a generic entrypoint
+  would rewrite 1.4. New files:
+  - `deploy/Dockerfile.plugin_job`: same base as `Dockerfile.job`, copies all
+    of `examples/` and `demo_agent/`, `ENTRYPOINT ["python"]`. The script path
+    is the Job argument.
+  - `deploy/deploy_plugin_job.sh`: copy of `deploy_job.sh` with
+    `SCRIPT=examples/03_logging_plugin.py|examples/04_debug_plugin.py`
+    selecting the script and `JOB` defaulting to `adk-plugin-job` /
+    `adk-debug-plugin-job` from it. Passes `--args="$SCRIPT"` at deploy time.
+    Reads `PROJECT_ID` (required), `REGION` (default `us-central1`), and
+    `MODEL_LOCATION` (default `global`) exactly as `deploy_job.sh` does.
+    Optional `LOG_LEVEL` and `BUCKET` (see D7). No project, region, or
+    bucket name appears in the script, the Dockerfile, or the tutorial
+    commands; only in the `export` line the reader types.
+  Alternative: extend `deploy_job.sh` with a `SCRIPT=` switch. Rejected: it
+  would carry two Dockerfiles and two entrypoint conventions in one script.
+- **D6: the level test in 3.2 uses the `LOG_LEVEL` env var already read by
+  `demo_agent/agent.py`** (added for 1.6). Example 03 configures no logging
+  itself, so setting `LOG_LEVEL=INFO` turns stream 2 on and `LOG_LEVEL=WARNING`
+  turns it off, with the plugin narration untouched either way. That is the
+  1.4 experiment (INFO run, then WARNING run) applied to a plugin, and the
+  observed proof for 3.5's "independent of the level" row. Per-execution
+  override: `gcloud run jobs execute ... --update-env-vars=LOG_LEVEL=WARNING`.
+- **D7: 3.4's finding is that the file is gone; the fix is a Cloud Storage
+  volume.** A Job's filesystem is discarded when the execution ends, so the
+  YAML written to `/app/adk_debug.yaml` never reaches you, and Cloud Logging
+  only holds the two `print()` lines. The section shows that first, then
+  mounts a bucket (`--add-volume=name=out,type=cloud-storage,bucket=$BUCKET`
+  plus `--add-volume-mount=volume=out,mount-path=/mnt/out`) and points the
+  plugin at it. Requires one small change to example 04: read the output path
+  from `DEBUG_OUTPUT` when set, default unchanged. Alternative: `cat` the
+  file to stdout at the end of the script so it lands in Cloud Logging.
+  Rejected as the primary path because it undoes the "file, not stream"
+  lesson, but mention it as the quick hack.
+- **D8: project, region, and bucket come from the environment.** The
+  tutorial's `export PROJECT_ID=... REGION=...` convention from 1.4 carries
+  over, plus `BUCKET`. When `BUCKET` is unset in 3.4, the script derives
+  `${PROJECT_ID}-adk-debug` and creates it in `$REGION` if it does not exist.
+  The verification runs use whatever I export in my shell (the same project
+  the 1.4-1.7 runs used); the project name appears only in the "Verification
+  status" section, as a record of what was run, never in a command. Console
+  blocks with project-specific output get the project masked the way 1.4
+  does (`projects/.../logs/...`). Cost: a few Job executions and one small
+  object.
+- **D9: do not claim `adk web` / `adk run` support for plugins** unless a
+  quick grep of the installed `google/adk/cli` confirms it.
+
+## Ask 1: 3.1 additions
+
+### 1a. How the plugin is invoked (new block after the wiring snippet)
+
+Three facts, each one or two sentences, then a short table:
+
+1. `BasePlugin` defines 14 async hook methods (`on_user_message_callback`,
+   `before_run_callback`, `on_event_callback`, `after_run_callback`,
+   `before/after_agent_callback`, `before/after_model_callback`,
+   `before/after_tool_callback`, three error hooks, `close`). Every one
+   returns `None` by default. A plugin overrides the hooks it cares about.
+2. `App(plugins=[...])` hands the list to a `PluginManager`. At each lifecycle
+   point the runner calls the matching `run_*_callback`, which walks the
+   plugins in registration order. Plugins run **before** agent callbacks.
+3. Early exit: if any hook returns a non-`None` value, remaining plugins and
+   agent callbacks for that point are skipped and the value is used instead
+   (a `before_tool_callback` returning a dict replaces the tool result).
+   `LoggingPlugin` returns `None` from every hook, so it is a pure observer.
+
+Quote the `PluginManager` docstring sentence on early exit (lines 70-74).
+
+### 1b. What "no arguments" configures
+
+The only constructor parameter is `name`:
+
+```python
+def __init__(self, name: str = "logging_plugin"):
+    super().__init__(name)
+```
+
+| Setting | Value | Where |
+|---|---|---|
+| Prefix | `[logging_plugin]` (the `name`) | `_log` |
+| Sink | `print()` to stdout, grey ANSI (`\033[90m`) | `_log` |
+| Level / handler / formatter | none; the `logging` module is never touched | whole file |
+| Text and system-instruction truncation | 200 chars | `_format_content`, `before_model_callback` |
+| Tool args and results truncation | 300 chars | `_format_args` |
+
+Quote `_log`:
+
+```python
+def _log(self, message: str) -> None:
+    # ANSI color codes: \033[90m for grey, \033[0m to reset
+    formatted_message: str = f"\033[90m[{self.name}] {message}\033[0m"
+    print(formatted_message)
+```
+
+Point: `--log_level` cannot reach this output, and neither can a
+`dictConfig`. This is the mechanism behind the existing "catch" callout,
+which stays as is and now gets its evidence in 3.2.
+
+### 1c. One hook, end to end
+
+Quote `before_tool_callback` (the source of the `TOOL STARTING` block) so the
+reader can map source lines to output lines:
+
+```python
+async def before_tool_callback(self, *, tool, tool_args, tool_context):
+    self._log(f"🔧 TOOL STARTING")
+    self._log(f"   Tool Name: {tool.name}")
+    self._log(f"   Agent: {tool_context.agent_name}")
+    self._log(f"   Function Call ID: {tool_context.function_call_id}")
+    self._log(f"   Arguments: {self._format_args(tool_args)}")
+    return None
+```
+
+### 1d. Expected behavior: the full sequence
+
+Replace the trimmed console block with the full capture from a fresh run of
+example 03, then a numbered sequence for one tool-calling turn:
+
+1. `🚀 USER MESSAGE RECEIVED` (invocation, session, user, app, root agent)
+2. `🏃 INVOCATION STARTING`
+3. `🤖 AGENT STARTING`
+4. `🧠 LLM REQUEST` (model, agent, system instruction, available tools)
+5. `🧠 LLM RESPONSE` with `function_call: get_weather` and token usage
+6. `📢 EVENT YIELDED` (function call event)
+7. `🔧 TOOL STARTING` / `🔧 TOOL COMPLETED`
+8. `📢 EVENT YIELDED` (function response event)
+9. second `🧠 LLM REQUEST` / `🧠 LLM RESPONSE` with `text: '...'`
+10. `📢 EVENT YIELDED` with `Final Response: True`
+11. `🤖 AGENT COMPLETED`, `✅ INVOCATION COMPLETED`
+
+Confirm the order from the run before writing it.
+
+**What you will not see.** `LLM REQUEST` prints the model, the first 200
+characters of the system instruction, and the tool names, but **not** the
+conversation contents. The source says why:
+
+```python
+# Note: Content logging removed due to type compatibility issues
+# Users can still see content in the LLM response
+```
+
+So the exact prompt is still a DEBUG-level or `DebugLoggingPlugin` job. This
+sets up 3.3.
+
+## Ask 2: new 3.2 LoggingPlugin on Cloud Run
+
+**Why you are here.** 3.1's callout says `print()` output ignores your logging
+config. On your laptop that is invisible. In the cloud it decides what Cloud
+Logging receives. Same move as 1.4: deploy the unmodified script as a Job,
+run it twice, read back severity and payload.
+
+**Do this.**
+
+```bash
+export PROJECT_ID=your-project REGION=us-central1
+SCRIPT=examples/03_logging_plugin.py ./deploy/deploy_plugin_job.sh   # deploys adk-plugin-job, executes once
+gcloud run jobs execute adk-plugin-job \
+  --project="$PROJECT_ID" --region="$REGION" \
+  --update-env-vars=LOG_LEVEL=WARNING --wait
+gcloud logging read \
+  'resource.type="cloud_run_job" resource.labels.job_name="adk-plugin-job"' \
+  --project="$PROJECT_ID" --limit=60 \
+  --format='table(severity,textPayload)' --freshness=15m
+```
+
+First execution runs with `LOG_LEVEL=INFO` (set by the deploy script), the
+second with `WARNING`.
+
+**You will see** (predicted; replace with the real capture):
+
+- Both executions carry the full `[logging_plugin]` narration. The WARNING
+  execution has no `INFO - google_adk...` lines; the INFO execution
+  interleaves them with the narration.
+- Every narration line is filed with Default severity. It is on stdout, so
+  the stderr question from 1.4 does not even arise.
+- The ANSI bytes arrive in `textPayload` as literal escape sequences. Confirm
+  the exact rendering (`\x1b[90m`, `[90m`, or stripped) from the run; whatever
+  it is, the point is that the terminal coloring is now noise in the payload.
+- Burst grouping: several narration lines may share one entry (same note as
+  1.4).
+
+**What it means.** Two findings that mirror 1.4:
+
+1. The plugin is independent of the level dial. Turning stream 2 to WARNING
+   changed nothing about the narration, because the plugin never goes
+   through `logging`. Good in dev, and exactly why it is the wrong tool here:
+   you cannot turn it down in production without removing it.
+2. The narration reaches Cloud Logging as prose with color codes and Default
+   severity. It is readable in the console, but nothing in it is a field you
+   can query or alert on. Part 4 makes the same hooks emit structured records.
+
+Add the same "Tear down" line as 1.4 (`gcloud run jobs delete adk-plugin-job`).
+
+## Ask 3: 3.3 additions (existing 3.2, renumbered)
+
+### 3a. Comparison table (right after the "Why")
+
+| | `LoggingPlugin` | `DebugLoggingPlugin` |
+|---|---|---|
+| Sink | `print()` to stdout | YAML file, one document per invocation, appended with `---` |
+| When it writes | immediately, at every hook | buffers entries in memory per invocation; writes once in `after_run_callback` |
+| Detail | truncated (200 / 300 chars); no request contents | full request contents, generation config, tool list, responses, session state snapshot |
+| Redaction | none | credential models, secret-named keys, armored private-key blocks, all `temp:` state |
+| File safety | n/a | created `0600`; warns once if an existing file is wider than owner-only |
+| Constructor | `name` only | keyword-only: `name`, `output_path`, `include_session_state`, `include_system_instruction` |
+| Own diagnostics | none | `logging` warnings/errors under `google_adk.google.adk.plugins.debug_logging_plugin` |
+| Failure mode | none | a write failure is logged, never raised; the turn still completes |
+
+### 3b. Snippets
+
+Constructor, showing defaults and the keyword-only signature:
+
+```python
+def __init__(
+    self,
+    *,
+    name: str = "debug_logging_plugin",
+    output_path: str = "adk_debug.yaml",
+    include_session_state: bool = True,
+    include_system_instruction: bool = True,
+):
+```
+
+Capture, from `before_model_callback`, to show it records the whole request
+as data rather than a formatted line (contrast with 1c):
+
+```python
+request_data = {
+    "model": llm_request.model,
+    "content_count": len(llm_request.contents),
+    "contents": [self._serialize_content(c) for c in llm_request.contents],
+}
+if llm_request.tools_dict:
+    request_data["tools"] = list(llm_request.tools_dict.keys())
+...
+self._add_entry(callback_context.invocation_id, "llm_request",
+                agent_name=callback_context.agent_name, **request_data)
+```
+
+Write, from `after_run_callback`: the `0600` create, the append, the YAML
+document separator:
+
+```python
+fd = os.open(self._output_path,
+             os.O_WRONLY | os.O_CREAT | os.O_APPEND, _OUTPUT_FILE_MODE)  # 0o600
+with os.fdopen(fd, "a", encoding="utf-8") as f:
+    f.write("---\n")
+    yaml.dump(output_data, f, default_flow_style=False,
+              allow_unicode=True, sort_keys=False, width=120)
+```
+
+### 3c. Prose additions
+
+- Buffered, not streamed: nothing appears in the file until the invocation
+  ends. If the process dies mid-turn, that turn is lost.
+- List the `entry_type` values in the order they appear in the captured file
+  (confirm from the run).
+- The `temp:` rule blanks all temporary state, not only credentials. Quote
+  the docstring sentence.
+- Example 04's explicit `include_*=True` arguments are the defaults (D4).
+- Example 04 gains `DEBUG_OUTPUT` (D7). One line in the text: "the path comes
+  from `DEBUG_OUTPUT` when set, so 3.4 can point it at a mounted bucket."
+
+## Ask 4: new 3.4 DebugLoggingPlugin on Cloud Run
+
+**Why you are here.** 3.3 wrote a file. A Cloud Run Job's filesystem is
+thrown away when the execution ends. So where does the capture go?
+
+**Do this**, part one, the naive deploy:
+
+```bash
+SCRIPT=examples/04_debug_plugin.py ./deploy/deploy_plugin_job.sh   # deploys adk-debug-plugin-job, executes once
+gcloud logging read \
+  'resource.type="cloud_run_job" resource.labels.job_name="adk-debug-plugin-job"' \
+  --project="$PROJECT_ID" --limit=20 \
+  --format='table(severity,textPayload)' --freshness=15m
+```
+
+**You will see** (predicted): only the script's two `print()` lines,
+`FINAL ANSWER: ...` and `Full invocation captured to: /app/adk_debug.yaml`,
+plus `Container called exit(0)`. No narration (this plugin prints nothing), no
+YAML. The file was written and then discarded with the container.
+
+**What it means.** A file-writing plugin needs a filesystem that outlives the
+execution. Cloud Run can mount a Cloud Storage bucket as a volume.
+
+**Do this**, part two, the bucket mount:
+
+```bash
+export BUCKET="${PROJECT_ID}-adk-debug"   # any bucket name you own; created in $REGION if missing
+MOUNT=1 SCRIPT=examples/04_debug_plugin.py ./deploy/deploy_plugin_job.sh
+gcloud storage cat "gs://$BUCKET/adk_debug.yaml" | head -40
+```
+
+With `MOUNT=1`, the script adds the volume flags for `$BUCKET` and sets
+`DEBUG_OUTPUT=/mnt/out/adk_debug.yaml` on the Job. `PROJECT_ID` and `REGION`
+are the same variables as every other deploy in this tutorial.
+
+**You will see** the same YAML document as 3.3, read from the bucket. Also
+check Cloud Logging for one extra line: the plugin's own
+`logging.warning` about file mode, because Cloud Storage FUSE reports a mode
+wider than `0600`. Example 04 configures no handler, so Python's last-resort
+handler puts that warning on stderr. Predicted, confirm from the run; if it
+fires, it is a good example of stream 2 speaking while the plugin itself is
+silent.
+
+**What it means.** The plugin behaved exactly as on your laptop; only the
+disk changed. Two cautions: the file now holds full prompts in a bucket, so
+bucket IAM is the new `0600`; and this is still a debugging capture, not a
+log pipeline. If you find yourself doing this routinely, you want Part 4.
+
+Quick hack, one sentence: `cat` the file at the end of the script and it
+lands in Cloud Logging as one big text payload. Works, but throws away the
+"file, not stream" property that made the plugin useful.
+
+Verify live before writing: `O_APPEND` and `os.open` with a mode on the
+gcsfuse mount, and whether the `0o077` warning actually fires. If append is
+refused, fall back to the `cat` approach as the primary path and say why.
+
+Tear down: delete the job, and the object if you want.
+
+## Ask 5: new 3.5 Plugin or level dial?
+
+### 5a. Benefits, tied back to the four streams
+
+Built-in ADK logging (stream 2) is text lines under `google_adk` at a level.
+A plugin gets **objects at semantic hook points**.
+
+| Benefit | What it means in practice |
+|---|---|
+| Objects, not strings | `after_model_callback` receives `LlmResponse` with `usage_metadata`; you never parse a DEBUG dump for token counts |
+| Independent of the level | 3.2 showed it: WARNING silenced stream 2 and the narration kept going |
+| One registration, app-wide | fires for every agent and tool in the `App`; a per-agent callback needs wiring per agent |
+| You own the sink | same hooks feed `print()` (3.1), YAML (3.3), JSON `logging` records (Part 4), or BigQuery |
+
+Also say what built-in DEBUG still does better: the wire-level request, HTTP
+retries, session-service work, none of which have plugin hooks. The two are
+complementary.
+
+### 5b. Use cases (three, one short paragraph each)
+
+1. **Wrong tool arguments in dev.** Run at WARNING so stream 2 is silent,
+   attach `LoggingPlugin`, watch `Arguments:` lines. Ties to 1c and 3.2.
+2. **A reproducible bug report.** Attach `DebugLoggingPlugin`, reproduce the
+   turn, attach the YAML. Or capture before and after a prompt change and
+   diff the two documents. From a Job, that means the bucket in 3.4.
+3. **Token cost while tuning a prompt.** `Token Usage` per model call from
+   `LoggingPlugin`, or `usage_metadata` in the YAML, without writing a
+   formatter. Bridges to Part 4, which makes the same numbers queryable.
+
+### 5c. Update the "How to choose" table
+
+No row changes. Add "see 3.5" to the `LoggingPlugin` and
+`DebugLoggingPlugin` rows.
+
+## Files touched
+
+| File | Change |
+|---|---|
+| `ai/adk/logging/TUTORIAL.md` | Part 3 rewrite per above; "How to choose" back-refs; "Verification status" gains the 3.2 / 3.4 runs |
+| `ai/adk/logging/deploy/Dockerfile.plugin_job` | new (D5) |
+| `ai/adk/logging/deploy/deploy_plugin_job.sh` | new (D5, D7) |
+| `ai/adk/logging/examples/04_debug_plugin.py` | `OUTPUT` from `DEBUG_OUTPUT` env var when set (D7) |
+| `ai/adk/logging/README.md` | one line if it lists the deploy scripts (check) |
+
+## Checklist
+
+**Status: executed 2026-09-03. All items done; jobs torn down, bucket kept.**
+
+- [x] Run `examples/03_logging_plugin.py` locally; save full console output
+- [x] Run `examples/04_debug_plugin.py` locally; save `entry_type` sequence
+- [x] Check `adk web` / `adk run` plugin loading in `google/adk/cli` (D9)
+- [x] Write `Dockerfile.plugin_job` and `deploy_plugin_job.sh`
+- [x] Add `DEBUG_OUTPUT` to example 04
+- [x] Deploy and execute `adk-plugin-job` at INFO and WARNING; read logs back; save output
+- [x] Deploy and execute `adk-debug-plugin-job` without bucket; read logs back
+- [x] Redeploy with `MOUNT=1` (bucket derived from `PROJECT_ID`); `gcloud storage cat` the YAML; check for the mode warning
+- [x] Write 3.1 (1a-1d), 3.2, 3.3 (3a-3c), 3.4, 3.5; renumber headings
+- [x] Update "How to choose" back-refs and "Verification status"
+- [x] Writing-guideline pass on the new text only
+- [x] Verify every quoted snippet against the 2.8.0 source
+- [x] Tear down both jobs (leave the bucket unless told otherwise)
+- [x] Grep the new files and Part 3 for any literal project, region, or bucket name
+
+## Size budget
+
+About 220-260 added lines in `TUTORIAL.md`. If 3.5 grows past 40 lines, cut a
+use case, not the table. 3.2 and 3.4 should each be shorter than 1.4.


### PR DESCRIPTION
## Summary

Expands Parts 3 and 4 of the ADK logging tutorial (`ai/adk/logging/TUTORIAL.md`).

**Part 3 — the built-in plugins, in depth.** Reworked into five sections:
- 3.1 `LoggingPlugin`: how the one line works (BasePlugin hooks, PluginManager early-exit), what `LoggingPlugin()` fixes with no arguments, and its stated dev-only intent quoted from the source.
- 3.2 `LoggingPlugin` on Cloud Run (optional): deploys example 03 as a Job; the narration survives `LOG_LEVEL=WARNING` and lands on stdout with Default severity and literal ANSI bytes.
- 3.3 `DebugLoggingPlugin`: comparison table and source snippets (constructor, capture, write).
- 3.4 `DebugLoggingPlugin` on Cloud Run (optional): the YAML dies with the container until a Cloud Storage volume is mounted.
- 3.5 Plugin or level dial?

**Part 4 — callback vs plugin.** New 4.1 "Callback or plugin?" subsection: frames callback/plugin logging as complementary to ADK's built-in logging (framework-health questions vs tool/cost questions), shows the per-agent callback alternative with the correct `(tool, args, tool_context)` signature, explains the separate `agent.telemetry` logger namespace, and gives a decision table. The deploy helper now also covers `examples/05_structured_plugin.py`.

## New files
- `deploy/Dockerfile.plugin_job`, `deploy/deploy_plugin_job.sh` — one image for the plugin examples; project/region/bucket read from the environment.
- `docs/adk-logging-part3-plugin-depth.md` — the working plan.

## Verification
Every console block in 3.2 and 3.4 is captured from real Cloud Run Job runs against `jwd-gcp-demos` (2026-09-03); jobs torn down, bucket kept. All quoted plugin snippets verified against google-adk 2.8.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)